### PR TITLE
Ajout d'un fichier de config au format YAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<jena.version>3.7.0</jena.version>
 		<jaxrs.version>2.1</jaxrs.version>
 		<slf4j.version>1.7.5</slf4j.version>
+		<war-directory>C:\\Dev\\webapp</war-directory>
 	</properties>
 	<dependencies>
 		<!-- App monitoring -->
@@ -92,6 +93,22 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+		<!-- Dépendence nécessaire à la lecture d'un fichier YAML -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>MiCorr-WebServices</finalName>
@@ -117,6 +134,14 @@
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>2.6</version>
+					<configuration>
+						<outputDirectory>${war-directory}</outputDirectory>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/src/main/java/ch/hearc/ig/micorr/rest/business/YamlConfig.java
+++ b/src/main/java/ch/hearc/ig/micorr/rest/business/YamlConfig.java
@@ -1,0 +1,51 @@
+package ch.hearc.ig.micorr.rest.business;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class YamlConfig {
+	
+	@JsonProperty("fuseki-address")
+	private String fusekiAddress;
+	
+	@JsonProperty("timeout-query")
+	private String timeoutQuery;
+	
+	private Map<String, String> queries;
+
+	public YamlConfig() {
+		super();
+	}
+
+	public String getFusekiAddress() {
+		return fusekiAddress;
+	}
+
+	public void setFusekiAddress(String fusekiAddress) {
+		this.fusekiAddress = fusekiAddress;
+	}
+
+	public String getTimeoutQuery() {
+		return timeoutQuery;
+	}
+
+	public void setTimeoutQuery(String timeoutQuery) {
+		this.timeoutQuery = timeoutQuery;
+	}
+
+	public Map<String, String> getQueries() {
+		return queries;
+	}
+
+	public void setQueries(Map<String, String> queries) {
+		this.queries = queries;
+	}
+
+	@Override
+	public String toString() {
+		return "YamlConfig [fusekiAddress=" + fusekiAddress + ", timeoutQuery=" + timeoutQuery + ", queries=" + queries
+				+ "]";
+	}
+	
+}


### PR DESCRIPTION
Ajout d'un fichier de config au format YAML contenant les informations suivantes : 

- l'adresse du serveur Apache Jena Fuseki
- le timeout sur la durée de recherche d'une requête SPARQL
- les différentes requêtes SPARQL nécessaires à l'interrogations des données
